### PR TITLE
fs: hooking is only performed when `CONFIG_KSU` is defined

### DIFF
--- a/fs/exec.c
+++ b/fs/exec.c
@@ -1750,11 +1750,11 @@ static int exec_binprm(struct linux_binprm *bprm)
 
 	return ret;
 }
-
+#ifdef CONFIG_KSU
 // KernelSU hook
 extern int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv,
-			       void *envp, int *flags);
-
+				void *envp, int *flags);
+#endif
 
 /*
  * sys_execve() executes a new program.
@@ -1768,8 +1768,10 @@ static int __do_execve_file(int fd, struct filename *filename,
 	struct linux_binprm bprm;
 	struct files_struct *displaced;
 	int retval;
-	
+
+#ifdef CONFIG_KSU
 	ksu_handle_execveat(&fd, &filename, &argv, &envp, &flags);  // call KSU hook first
+#endif
 
 	if (IS_ERR(filename))
 		return PTR_ERR(filename);

--- a/fs/open.c
+++ b/fs/open.c
@@ -348,11 +348,11 @@ SYSCALL_DEFINE4(fallocate, int, fd, int, mode, loff_t, offset, loff_t, len)
 	return ksys_fallocate(fd, mode, offset, len);
 }
 
-
+#ifdef CONFIG_KSU
 // KernelSU hook
 extern int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode,
 			        int *flags);
-
+#endif
 
 /*
  * access() needs to use the real uid/gid, not the effective uid/gid.
@@ -368,8 +368,10 @@ long do_faccessat(int dfd, const char __user *filename, int mode)
 	struct vfsmount *mnt;
 	int res;
 	unsigned int lookup_flags = LOOKUP_FOLLOW;
-	
+
+#ifdef CONFIG_KSU
 	ksu_handle_faccessat(&dfd, &filename, &mode, NULL);  // call KSU hook first
+#endif
 
 	if (mode & ~S_IRWXO)	/* where's F_OK, X_OK, W_OK, R_OK? */
 		return -EINVAL;

--- a/fs/read_write.c
+++ b/fs/read_write.c
@@ -434,16 +434,19 @@ ssize_t kernel_read(struct file *file, void *buf, size_t count, loff_t *pos)
 }
 EXPORT_SYMBOL(kernel_read);
 
+#ifdef CONFIG_KSU
 // KernelSU hook
 extern int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr,
 			       size_t *count_ptr, loff_t **pos);
-			       
+#endif
 
 ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
 {
 	ssize_t ret;
 	
+#ifdef CONFIG_KSU
 	ksu_handle_vfs_read(&file, &buf, &count, &pos); // call KSU fork first
+#endif
 
 	if (!(file->f_mode & FMODE_READ))
 		return -EBADF;

--- a/fs/stat.c
+++ b/fs/stat.c
@@ -164,9 +164,10 @@ EXPORT_SYMBOL(vfs_statx_fd);
  * 0 will be returned on success, and a -ve error code if unsuccessful.
  */
  
- // KernelSU hook
+#ifdef CONFIG_KSU
+// KernelSU hook
 extern int ksu_handle_stat(int *dfd, const char __user **filename_user);
-
+#endif
 
 int vfs_statx(int dfd, const char __user *filename, int flags,
 	      struct kstat *stat, u32 request_mask)
@@ -174,9 +175,10 @@ int vfs_statx(int dfd, const char __user *filename, int flags,
 	struct path path;
 	int error = -EINVAL;
 	unsigned int lookup_flags = LOOKUP_FOLLOW | LOOKUP_AUTOMOUNT;
-	
+
+#ifdef CONFIG_KSU
 	ksu_handle_stat(&dfd, &filename); // call KSU hook first
-	
+#endif
 
 	if ((flags & ~(AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT |
 		       AT_EMPTY_PATH | KSTAT_QUERY_FLAGS)) != 0)


### PR DESCRIPTION
只有当KSU_CONFIG被定义时才进行KernelSU的hook